### PR TITLE
ConverterProvider.converter ConverterName List of values

### DIFF
--- a/src/main/java/walkingkooka/convert/provider/ConverterProvider.java
+++ b/src/main/java/walkingkooka/convert/provider/ConverterProvider.java
@@ -37,6 +37,7 @@ package walkingkooka.convert.provider;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -47,16 +48,18 @@ import java.util.Set;
 public interface ConverterProvider {
 
     /**
-     * Resolves the given {@link ConverterSelector} to a {@link Converter}.
+     * Resolves the given {@link ConverterName} to a {@link Converter} with the given parameter values.
      */
-    <C extends ConverterContext> Optional<Converter<C>> converter(final ConverterSelector selector);
+    <C extends ConverterContext> Optional<Converter<C>> converter(final ConverterName name,
+                                                                  final List<?> values);
 
     /**
-     * Helper that invokes {@link #converter(ConverterSelector)} and throws a {@link IllegalArgumentException}
+     * Helper that invokes {@link #converter(ConverterName, List)} and throws a {@link IllegalArgumentException}
      * if none was found.
      */
-    default <C extends ConverterContext> Converter<C> converterOrFail(final ConverterSelector name) {
-        return this.<C>converter(name)
+    default <C extends ConverterContext> Converter<C> converterOrFail(final ConverterName name,
+                                                                      final List<?> values) {
+        return this.<C>converter(name, values)
                 .orElseThrow(
                         () -> new IllegalArgumentException("Unknown converter " + name)
                 );

--- a/src/main/java/walkingkooka/convert/provider/ConverterProviderTesting.java
+++ b/src/main/java/walkingkooka/convert/provider/ConverterProviderTesting.java
@@ -18,11 +18,13 @@
 package walkingkooka.convert.provider;
 
 import org.junit.jupiter.api.Test;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.convert.Converter;
 import walkingkooka.reflect.ClassTesting2;
 import walkingkooka.text.printer.TreePrintableTesting;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
@@ -32,52 +34,31 @@ public interface ConverterProviderTesting<T extends ConverterProvider> extends C
         TreePrintableTesting {
 
     @Test
-    default void testConverterWithNullFails() {
+    default void testConverterWithNullNameFails() {
         assertThrows(
                 NullPointerException.class,
                 () -> this.createConverterProvider()
-                        .converter(null)
+                        .converter(
+                                null,
+                                Lists.empty()
+                        )
         );
     }
 
-    default void converterAndCheck(final ConverterSelector selector) {
-        this.converterAndCheck(
-                this.createConverterProvider(),
-                selector,
-                Optional.empty()
-        );
-    }
-
-    default void converterAndCheck(final ConverterProvider provider,
-                                   final ConverterSelector selector) {
-        this.converterAndCheck(
-                provider,
-                selector,
-                Optional.empty()
+    @Test
+    default void testConverterWithNullValueFails() {
+        assertThrows(
+                NullPointerException.class,
+                () -> this.createConverterProvider()
+                        .converter(
+                                ConverterName.BOOLEAN_TO_NUMBER,
+                                null
+                        )
         );
     }
 
     default void converterAndCheck(final ConverterSelector selector,
                                    final Converter<?> expected) {
-        this.converterAndCheck(
-                this.createConverterProvider(),
-                selector,
-                Optional.of(expected)
-        );
-    }
-
-    default void converterAndCheck(final ConverterProvider provider,
-                                   final ConverterSelector selector,
-                                   final Converter<?> expected) {
-        this.converterAndCheck(
-                provider,
-                selector,
-                Optional.of(expected)
-        );
-    }
-
-    default void converterAndCheck(final ConverterSelector selector,
-                                   final Optional<Converter<?>> expected) {
         this.converterAndCheck(
                 this.createConverterProvider(),
                 selector,
@@ -87,11 +68,45 @@ public interface ConverterProviderTesting<T extends ConverterProvider> extends C
 
     default void converterAndCheck(final ConverterProvider provider,
                                    final ConverterSelector selector,
+                                   final Converter<?> expected) {
+        this.checkEquals(
+                expected,
+                selector.parseTextAndCreate(provider)
+        );
+    }
+
+    default void converterAndCheck(final ConverterName name,
+                                   final List<?> values,
+                                   final Converter<?> expected) {
+        this.converterAndCheck(
+                name,
+                values,
+                Optional.of(expected)
+        );
+    }
+
+    default void converterAndCheck(final ConverterName name,
+                                   final List<?> values,
+                                   final Optional<Converter<?>> expected) {
+        this.converterAndCheck(
+                this.createConverterProvider(),
+                name,
+                values,
+                expected
+        );
+    }
+
+    default void converterAndCheck(final ConverterProvider provider,
+                                   final ConverterName name,
+                                   final List<?> values,
                                    final Optional<Converter<?>> expected) {
         this.checkEquals(
                 expected,
-                provider.converter(selector),
-                selector::toString
+                provider.converter(
+                        name,
+                        values
+                ),
+                () -> provider + " " + name + " " + values
         );
     }
 

--- a/src/main/java/walkingkooka/convert/provider/ConvertersConverterProvider.java
+++ b/src/main/java/walkingkooka/convert/provider/ConvertersConverterProvider.java
@@ -18,6 +18,7 @@
 package walkingkooka.convert.provider;
 
 import walkingkooka.Cast;
+import walkingkooka.collect.list.Lists;
 import walkingkooka.collect.set.Sets;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
@@ -65,30 +66,22 @@ final class ConvertersConverterProvider implements ConverterProvider {
     }
 
     @Override
-    public <C extends ConverterContext> Optional<Converter<C>> converter(final ConverterSelector selector) {
-        Objects.requireNonNull(selector, "selector");
+    public <C extends ConverterContext> Optional<Converter<C>> converter(final ConverterName name,
+                                                                         final List<?> values) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(values, "values");
 
-        Converter<C> converter = null;
+        Converter<?> converter = null;
 
-        // first verify the ConverterSelection#name exists...
-        if (ConverterName.NAME_TO_FACTORY.containsKey(selector.name())) {
-
-            // try and parseText.
-            converter = selector.parseTextAndCreate(
-                    (n, p) -> {
-                        final Function<List<?>, Converter<?>> creator = ConverterName.NAME_TO_FACTORY.get(n);
-                        if (null == creator) {
-                            throw new IllegalArgumentException("Unknown converter " + CharSequences.quoteAndEscape(n.value()));
-                        }
-                        return Cast.to(
-                                creator.apply(p)
-                        );
-                    }
+        final Function<List<?>, Converter<?>> factory = ConverterName.NAME_TO_FACTORY.get(name);
+        if (null != factory) {
+            converter = factory.apply(
+                    Lists.immutable(values)
             );
         }
 
         return Optional.ofNullable(
-                converter
+                Cast.to(converter)
         );
     }
 

--- a/src/main/java/walkingkooka/convert/provider/EmptyConverterProvider.java
+++ b/src/main/java/walkingkooka/convert/provider/EmptyConverterProvider.java
@@ -21,6 +21,7 @@ import walkingkooka.collect.set.Sets;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
@@ -36,8 +37,10 @@ final class EmptyConverterProvider implements ConverterProvider{
     }
 
     @Override
-    public <C extends ConverterContext> Optional<Converter<C>> converter(final ConverterSelector selector) {
-        Objects.requireNonNull(selector, "selector");
+    public <C extends ConverterContext> Optional<Converter<C>> converter(final ConverterName name,
+                                                                         final List<?> values) {
+        Objects.requireNonNull(name, "name");
+        Objects.requireNonNull(values, "values");
 
         return Optional.empty();
     }

--- a/src/main/java/walkingkooka/convert/provider/FakeConverterProvider.java
+++ b/src/main/java/walkingkooka/convert/provider/FakeConverterProvider.java
@@ -20,12 +20,14 @@ package walkingkooka.convert.provider;
 import walkingkooka.convert.Converter;
 import walkingkooka.convert.ConverterContext;
 
+import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 
 public class FakeConverterProvider implements ConverterProvider {
     @Override
-    public <C extends ConverterContext> Optional<Converter<C>> converter(final ConverterSelector selector) {
+    public <C extends ConverterContext> Optional<Converter<C>> converter(final ConverterName name,
+                                                                         final List<?> values) {
         throw new UnsupportedOperationException();
     }
 

--- a/src/test/java/walkingkooka/convert/provider/ConvertersConverterProviderTest.java
+++ b/src/test/java/walkingkooka/convert/provider/ConvertersConverterProviderTest.java
@@ -58,28 +58,28 @@ public final class ConvertersConverterProviderTest implements ConverterProviderT
     @Test
     public void testConverterFactoryMethodWithoutParameters() {
         final Set<ConverterName> missing = Sets.sorted();
-
+        final ConvertersConverterProvider provider = this.createConverterProvider();
         int i = 0;
 
-        for(final Method method : Converters.class.getMethods()) {
-            if(JavaVisibility.PUBLIC != JavaVisibility.of(method)) {
-               continue;
+        for (final Method method : Converters.class.getMethods()) {
+            if (JavaVisibility.PUBLIC != JavaVisibility.of(method)) {
+                continue;
             }
 
-            if(false ==MethodAttributes.STATIC.is(method)) {
+            if (false == MethodAttributes.STATIC.is(method)) {
                 continue;
             }
 
             final String methodName = method.getName();
-            if("fake".equals(methodName)) {
+            if ("fake".equals(methodName)) {
                 continue;
             }
 
-            if(method.getReturnType() != Converter.class) {
+            if (method.getReturnType() != Converter.class) {
                 continue;
             }
 
-            if(method.getParameters().length > 0) {
+            if (method.getParameters().length > 0) {
                 continue;
             }
 
@@ -91,13 +91,13 @@ public final class ConvertersConverterProviderTest implements ConverterProviderT
             System.out.println(method + " " + name);
 
             final ConverterName converterName = ConverterName.with(name);
-            final Optional<Converter<ConverterContext>> converter = ConvertersConverterProvider.INSTANCE.converter(
-                    ConverterSelector.with(
-                            converterName,
-                            ""
-                    )
-            );
-            if(false == converter.isPresent()) {
+
+            try {
+                ConverterSelector.with(
+                        converterName,
+                        ""
+                ).parseTextAndCreate(provider);
+            } catch (final Exception fail) {
                 missing.add(converterName);
             }
 


### PR DESCRIPTION
- Closes https://github.com/mP1/walkingkooka-convert-provider/issues/33
- ConvertersConverterProvider doesnt support fetching Converter not present in Converters

- The above issue is fixed by this change, the ConverterSelector does the parsing and the ConverterProvider maps names and parameters to a Converter instance.